### PR TITLE
Add NoTypeInformation parameter to Export-Csv

### DIFF
--- a/ADTimeline.ps1
+++ b/ADTimeline.ps1
@@ -1910,7 +1910,7 @@ foreach ($criticalobject in $criticalobjects)
 # Sort by ftimeLastOriginatingChange to generate timeline and export as csv
 "$(Get-TimeStamp) Sorting AD replication metadata to generate timeline " | out-file log-adexport.log -append
 
-$Replinfo | Sort-Object -Property ftimeLastOriginatingChange | export-csv timeline.csv -delimiter ";"
+$Replinfo | Sort-Object -Property ftimeLastOriginatingChange | export-csv timeline.csv -delimiter ";" -NoTypeInformation
     if($error)
         { "$(Get-TimeStamp) Error while sortig timeline $($error)" | out-file log-adexport.log -append ; $error.clear() }
     else


### PR DESCRIPTION
To remove the useless first line of the CSV