### PR TITLE
Best effort fix errors while exporting objects

### DIFF
--- a/ADTimeline.ps1
+++ b/ADTimeline.ps1
@@ -2442,10 +2442,6 @@ if($gcobjects)
 	{
 	$gcobjects = $gcobjects | sort-object -unique -Property DistinguishedName
 	"$(Get-TimeStamp) Removed GC objects collected twice or more" | out-file $logfilename -append
-	$gcobjects | export-cliXML $gcADobjectsfilename -Encoding UTF8
-	"$(Get-TimeStamp) Global Catalog objects exported in gcADobjects.xml" | out-file $logfilename -append
-	if($error)
-		{ "$(Get-TimeStamp) Error while exporting global catalog objects $($error)" | out-file $logfilename -append ; $error.clear() }
 
 	# Exporting gcobjects, first try
 	try {

--- a/ADTimeline.ps1
+++ b/ADTimeline.ps1
@@ -2426,6 +2426,7 @@ catch {
 			return $true
 		}
 		catch {
+			"$(Get-TimeStamp) Discarding unserializable object $($_.DistinguishedName)" | out-file $logfilename -append
 			return $null
 		}
 	}
@@ -2461,6 +2462,7 @@ if($gcobjects)
 				return $true
 			}
 			catch {
+				"$(Get-TimeStamp) Discarding unserializable object $($_.distinguishedname)" | out-file $logfilename -append
 				return $null
 			}
 		}


### PR DESCRIPTION
Export-Clixml sometimes fails to exports all (gc)ADobjects, due to invalid encoded characters in some attributes.

Error observed usually during such events:
> Error while exporting objects retrieved via LDAP '￿', hexadecimal value 0xFFFF, is an invalid character

We end up with a truncated XML files, here is an example of such files:

```
<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
  <Obj RefId="0">
    <TN RefId="0">
[...]
 <Obj N="msExchAssistantsMaintenanceSchedule" RefId="13601">
        <TNRef RefId="1" />
        <LST>
          <S> <----- end of file
```

This does not seem to impact ingestion into splunk (maybe because extraction is done via regex?).

It is "kind of easily" reproductible by replacing a random attribute of such object with the following value:
`$adobjects[0].random_attribute="should-not-be-$([char]0xffff)-exportable"`

Nonetheless, it would be nice to exclude un-exportable objects and retry afterwards. The following PR uses the following static function to detect such objects:
`[System.Management.Automation.PSSerializer]::Serialize`

Note that it is a best-effort fix only, and has limitation (PSSerializer does not allow to set the encoding as in current code (UTF8), and has a default depth of 1 instead of 2 for export-clixml