### PR TITLE
# Modifications for Splunk Cloud Vetting :

### DIFF
--- a/SA-ADTimeline/default/app.conf
+++ b/SA-ADTimeline/default/app.conf
@@ -3,10 +3,10 @@
 #
 [package]
 id = SA-ADTimeline
+check_for_updates = true
 
 [install]
 is_configured = 0
-
 
 [ui]
 is_visible = 1
@@ -15,5 +15,8 @@ label = ADTimeline
 [launcher]
 author = Leonard SAVINA (@ldap389) - Nicolas LE CHAPELAIN
 description = ADTimeline app for Splunk is an open source project, code is available at https://github.com/ANSSI-FR/ADTimeline
-version = 1.2
+version = 1.2.1
 
+[id]
+name = SA-ADTimeline
+version = 1.2.1

--- a/SA-ADTimeline/default/data/ui/views/ad_infra.xml
+++ b/SA-ADTimeline/default/data/ui/views/ad_infra.xml
@@ -1,4 +1,4 @@
-<form>
+<form version="1.1">
   <label>Active Directory infrastructure</label>
   <fieldset submitButton="false"></fieldset>
   <row>

--- a/SA-ADTimeline/default/data/ui/views/investigate_timeframe.xml
+++ b/SA-ADTimeline/default/data/ui/views/investigate_timeframe.xml
@@ -1,4 +1,4 @@
-<form theme="light">
+<form version="1.1" theme="light">
   <label>Investigate timeframe</label>
   <fieldset submitButton="false"></fieldset>
   <row>

--- a/SA-ADTimeline/default/data/ui/views/sensitive_accounts.xml
+++ b/SA-ADTimeline/default/data/ui/views/sensitive_accounts.xml
@@ -1,4 +1,4 @@
-<form>
+<form version="1.1">
   <label>Sensitive accounts</label>
   <fieldset submitButton="false"></fieldset>
   <row>

--- a/SA-ADTimeline/default/data/ui/views/suspicious_activity.xml
+++ b/SA-ADTimeline/default/data/ui/views/suspicious_activity.xml
@@ -1,4 +1,4 @@
-<form>
+<form version="1.1">
   <label>Track suspicious activity</label>
   <search>
     <query>index=$ad_index$ host=$domain_host$ sourcetype=adtimeline  | where usnLocalChange = usnOriginatingChange | stats earliest(_time) as firstevent | fields firstevent</query>

--- a/SA-ADTimeline/default/data/ui/views/suspicious_exchange_activity.xml
+++ b/SA-ADTimeline/default/data/ui/views/suspicious_exchange_activity.xml
@@ -1,4 +1,4 @@
-<form>
+<form version="1.1">
   <label>Track suspicious Exchange activity</label>
   <fieldset submitButton="false"></fieldset>
   <row>

--- a/SA-ADTimeline/default/props.conf
+++ b/SA-ADTimeline/default/props.conf
@@ -1,7 +1,6 @@
 ﻿
 [adtimeline]
-BREAK_ONLY_BEFORE_DATE = 
-DATETIME_CONFIG = 
+BREAK_ONLY_BEFORE_DATE =
 FIELD_DELIMITER = ;
 INDEXED_EXTRACTIONS = csv
 KV_MODE = none
@@ -19,7 +18,6 @@ CHARSET = UTF-8
 [adobjects]
 TRANSFORMS-adxml_remove_header = adxml_remove_header
 BREAK_ONLY_BEFORE = ^\s\s<Obj RefId="\d+">
-DATETIME_CONFIG = 
 SHOULD_LINEMERGE = true
 LINE_BREAKER = ([\r\n]+)
 MAX_DAYS_AGO = 10951
@@ -58,7 +56,6 @@ MAX_EVENTS = 4096
 [gcobjects]
 TRANSFORMS-adxml_remove_header = adxml_remove_header
 BREAK_ONLY_BEFORE = ^\s\s<Obj RefId="\d+">
-DATETIME_CONFIG = 
 SHOULD_LINEMERGE = true
 LINE_BREAKER = ([\r\n]+)
 MAX_DAYS_AGO = 10951

--- a/SA-ADTimeline/metadata/default.meta
+++ b/SA-ADTimeline/metadata/default.meta
@@ -1,6 +1,6 @@
 
 # Application-level permissions
 []
-access = read : [ user ], write : [ admin, power ]
+access = read : [ user ], write : [ admin, power, sc_admin ]
 export = system
 owner = nobody


### PR DESCRIPTION
## app.conf

* adding a minor version 1.2.1
* adding the [id] stanza
* adding the check_for_updates to true by default

## props.conf

* datetime_config = "empty" doesn't pass the vetting, either put a none or a CURRENT, but can be left blank if the time can be parsed by Splunk which should be the case !

## Dashboards

* Simply adding the version="1.1" to match Splunk Cloud default XML version.

## default.meta

* adding the sc_admin user admin by default as admin doesn't exists in Splunk Cloud !